### PR TITLE
move from dollars to credits

### DIFF
--- a/apps/web/components/pages/Api/EndpointCard.tsx
+++ b/apps/web/components/pages/Api/EndpointCard.tsx
@@ -54,7 +54,7 @@ export const EndpointCard: FC<Props> = ({
           )}
         </div>
         <p className="block text-sm font-medium text-indigo-600 dark:text-indigo-300">
-          {price} {price === 'Free' ? '' : 'per request'}
+          {price} {price === 'Free' ? '' : 'credits'}
         </p>
       </div>
       <div className="md:grid md:grid-cols-2 md:gap-6">

--- a/apps/web/components/pages/Api/Features.tsx
+++ b/apps/web/components/pages/Api/Features.tsx
@@ -30,7 +30,7 @@ export const Features: FC<Props> = ({ features, serviceName }) => {
               Description
             </th>
             <th className="text-left text-xs font-medium tracking-wider py-3 text-zinc-400">
-              Pricing (per request)
+              Credits (per request)
             </th>
           </tr>
         </thead>

--- a/apps/web/components/pages/Pricing/ApiPriceBreakdown.tsx
+++ b/apps/web/components/pages/Pricing/ApiPriceBreakdown.tsx
@@ -27,7 +27,7 @@ export const ApiPriceBreakdown: FC<PricingItem> = ({
                     <th
                       scope="col"
                       className="px-6 py-3 text-left text-xs font-medium text-zinc-500 uppercase">
-                      Price (per request)
+                      Credits (per request)
                     </th>
                   </tr>
                 </thead>

--- a/apps/web/components/ui/Balance.tsx
+++ b/apps/web/components/ui/Balance.tsx
@@ -16,8 +16,8 @@ export const Balance: FC = () => {
       {isLoading ? (
         <Spinner />
       ) : (
-        <p className="font-bold text-3xl dark:text-white">
-          &#36;{data.toFixed(2)}
+        <p className="text-3xl dark:text-white">
+          {data.toFixed(2)}
         </p>
       )}
       <Link href={Routes.UserBilling}>

--- a/apps/web/components/ui/Header/LoggedInMenu.tsx
+++ b/apps/web/components/ui/Header/LoggedInMenu.tsx
@@ -72,7 +72,7 @@ export const LoggedInMenu: FC<LoggedInMenuProps> = ({ user }) => {
               <PulseLoader />
             ) : (
               <span className="font-medium text-indigo-600 dark:text-indigo-300">
-                ${(currentBalance.data || 0).toFixed(2)}
+                {(currentBalance.data || 0).toFixed(2)}
               </span>
             )}
           </div>

--- a/apps/web/pages/pricing.tsx
+++ b/apps/web/pages/pricing.tsx
@@ -81,7 +81,7 @@ const Pricing: NextPage<PricingProps> = ({ prices }) => {
               request per month account quota.
             </p>
             <p className="mb-4 text-sm">
-              Additional requests are charged at $0.000001 per request or in
+              Additional requests are charged at 0.000001 credit per request or in
               plain english $1 per million requests.
             </p>
           </div>

--- a/apps/web/utils/api.ts
+++ b/apps/web/utils/api.ts
@@ -17,7 +17,7 @@ export function splitEndpointTitle(str: string): string {
 
 export function getPrice({ pricing = {}, key }: GetPriceArguments): string {
   return pricing[key] && pricing[key] !== '0'
-    ? `$${parseInt(pricing[key]) / 1000000}`
+    ? `${parseInt(pricing[key]) / 1000000}`
     : 'Free'
 }
 


### PR DESCRIPTION
We're moving away from dollar values. While it will still be required to top-up using dollars, the internal balance will now be known as credits.