### PR TITLE
update scheduler.yml

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,13 +1,11 @@
 name: M3O Client Generation Scheduler
 on:
   push:
-    branches:
-      - main
-      - beta
     paths:
-      - '.github/workflows/scheduler.yml'
-      - 'cmd/**'
-
+      - 'cmd/api-publisher/**'
+      - 'cmd/m3o-client-gen/**'
+      - 'cmd/protoc-gen-openapi/**'
+      - 'cmd/release-note/**'
   repository_dispatch:
     types: [build_m3o_client,build_dart,build_go,build_ts,build_shell,build_cli]
 


### PR DESCRIPTION
Signed-off-by: Daniel Joudat <danieljoudat@gmail.com>

We don't need to trigger this workflow for every push to `main` / `beta`, we only need to trigger it when we make some changes in the `cmd` folder (except for client-generator the old one) or `micro/services` repo has been changed (repository_dispatch).