### PR TITLE
fix unmarshal error by adding omitempty tag

### DIFF
--- a/cmd/client-generator/main.go
+++ b/cmd/client-generator/main.go
@@ -1059,7 +1059,7 @@ func schemaToType(language, serviceName, typeName string, schemas map[string]*op
 				if typ == int64Type {
 					ret += ",string"
 				}
-				ret += "\"`"
+				ret += ",omitempty\"`"
 			}
 
 			if i < len(props) {

--- a/cmd/m3o-client-gen/go_generator.go
+++ b/cmd/m3o-client-gen/go_generator.go
@@ -346,9 +346,9 @@ func (g *goG) schemaToType(serviceName, typeName string, schemas map[string]*ope
 
 		// int64 represented as string
 		if meta.Value.Format == "int64" {
-			o += fmt.Sprintf(" `json:\"%v,string\"`", p)
+			o += fmt.Sprintf(" `json:\"%v,string,omitempty\"`", p)
 		} else {
-			o += fmt.Sprintf(" `json:\"%v\"`", p)
+			o += fmt.Sprintf(" `json:\"%v,omitempty\"`", p)
 		}
 
 		output = append(output, comments+o)


### PR DESCRIPTION
Signed-off-by: Daniel Joudat <danieljoudat@gmail.com>

fix the `{"id":"go.micro.client","code":500,"detail":"grpc: failed to unmarshal the received message json: cannot unmarshal string into Go value of type []json.RawMessage","status":"Internal Server Error"}` error thrown by m3o backend.

An example where that can occur is the following code example:

```go
func main() {
	client := m3o.New(os.Getenv("M3O_API_TOKEN"))
	rsp, err := client.Evchargers.Search(&evchargers.SearchRequest{
		Distance: 2000,
		Location: &evchargers.Coordinates{
			Latitude:  51.53336351319885,
			Longitude: -0.0252,
		},
	})
	fmt.Println(rsp, err)
}
```

We did not pass the **ConnectionTypes string json:"connection_types"** here, so when we call `json.Marshal` that missing attribute will be converted to `“connection_types”:””` as a result i.e it will have the **zero value** of string instead of the **json null value**.
