### PR TITLE
add x-frame-options and frame-ancestors headers to stop clickjacking

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,3 +1,18 @@
+const ContentSecurityPolicy = `
+  frame-ancestors 'self';
+`
+
+const securityHeaders = [
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN'
+  },
+  {
+    key: 'Content-Security-Policy',
+    value: ContentSecurityPolicy.replace(/\s{2,}/g, ' ').trim()
+  },
+]
+
 module.exports = {
   reactStrictMode: true,
   webpack(config) {
@@ -16,6 +31,14 @@ module.exports = {
       {
         source: '/:api/overview',
         destination: '/:api',
+      },
+    ]
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
       },
     ]
   },


### PR DESCRIPTION
Adds response headers to stop potential click jacking of things like the login page. Change means that m3o.com can't be iframed by anyone else