### PR TITLE
Dart clients - remove unused imports

### DIFF
--- a/cmd/m3o-client-gen/dart_generator.go
+++ b/cmd/m3o-client-gen/dart_generator.go
@@ -57,8 +57,10 @@ func (d *dartG) ServiceClient(serviceName, dartPath string, service service) {
 }
 
 func (d *dartG) schemaToType(serviceName, typeName string, schemas map[string]*openapi3.SchemaRef) string {
-	var jsonInt64 = `@JsonKey(fromJson: int64FromString, toJson: int64ToString)
-	{{ .type }}? {{ .parameter }}`
+	var jsonInt64 = `
+	@JsonKey(fromJson: int64FromString, toJson: int64ToString)
+	{{ .type }}? {{ .parameter }}
+	`
 	var normalType = `{{ .type }}? {{ .parameter }}`
 	var arrayType = `List<{{ .type }}>? {{ .parameter }}`
 	var mapType = `Map<{{ .type1 }}, {{ .type2 }}>? {{ .parameter }}`

--- a/cmd/m3o-client-gen/dart_template.go
+++ b/cmd/m3o-client-gen/dart_template.go
@@ -7,7 +7,11 @@ package main
 // {{ end }}
 // `
 
-const dartServiceTemplate = `{{ $service := .service }}import 'dart:convert';
+const dartServiceTemplate = `
+{{- $service := .service }}
+{{- if serviceHasStream $service.Spec $service.Name }}
+import 'dart:convert';
+{{- end }}
 import 'package:freezed_annotation/freezed_annotation.dart';
 import '../client/client.dart';
 

--- a/cmd/m3o-client-gen/generator.go
+++ b/cmd/m3o-client-gen/generator.go
@@ -103,6 +103,16 @@ func funcMap() map[string]interface{} {
 			// this is primarily used in dart template.
 			return strings.HasSuffix(typeName, "Response")
 		},
+		// Similar to isStream, this function checks if a service has
+		// a stream endpoint or not
+		"serviceHasStream": func(spec *openapi3.Swagger, service string) bool {
+			for _, v := range spec.Paths {
+				if _, ok := v.Post.Responses["stream"]; ok {
+					return true
+				}
+			}
+			return false
+		},
 		"requestTypeToResponseType": func(requestType string) string {
 			parts := camelcase.Split(requestType)
 			return strings.Join(parts[1:len(parts)-1], "") + "Response"


### PR DESCRIPTION
remove unused imports when a service does not have an endpoint that uses Stream

Signed-off-by: Daniel Joudat <danieljoudat@gmail.com>