### PR TITLE
Fix: Remove Ruby code from helloworld.py

### DIFF
--- a/examples/helloworld/helloworld.py
+++ b/examples/helloworld/helloworld.py
@@ -1,5 +1,4 @@
 import requests
-puts req.inspect
 import json
 import os
 


### PR DESCRIPTION
👋

In `m3o/examples/helloworld/helloworld.py`, there is a single line of Ruby code. I've removed it to allow `helloworld.py` to run:

```sh
~/workspace/m3o/examples/helloworld $ python3 -V
Python 3.9.12
~/workspace/m3o/examples/helloworld $ python3 helloworld.py
  File "/home/naltun/workspace/m3o/examples/helloworld/helloworld.py", line 2
    puts req.inspect
         ^
SyntaxError: invalid syntax
# One patch later...
~/workspace/m3o/examples/helloworld $ python3 helloworld.py
b'{"message":"Hello Alice"}'
```