### PR TITLE
Fix: Add correct URL to Functions div

### DIFF
--- a/apps/web/pages/cloud/index.tsx
+++ b/apps/web/pages/cloud/index.tsx
@@ -66,7 +66,7 @@ const CloudPage: NextPage<WithAuthProps> = ({
 	      </div>
 	    </div>
 	    <div className="mb-6 md:mb-0 text-left relative card hover:shadow-lg transition-shadow tbc">
-	      <Link href={`/cloud/apps`}>
+	      <Link href={`/cloud/functions`}>
 		<a className="absolute top-0 left-0 w-full h-full z-30"></a>
 	      </Link>
 	      <div className="relative z-40 pointer-events-none p-6 pb-0 md:pb-0">


### PR DESCRIPTION
In the Cloud services page, the `div` surrounding the `Functions` text is directing users to `/cloud/apps` instead of `/cloud/functions`. Update the `div` accordingly.